### PR TITLE
Fix module exports

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,15 +2,34 @@
 
 A collection of ESLint configurations for TypeScript and React projects. This package provides a set of pre-configured ESLint rules that follow best practices and common coding standards.
 
+## Requirements
+
+- ESLint v9 or higher
+- TypeScript v5 or higher (optional, but recommended for TypeScript projects)
+- Tailwind CSS v4 or higher (optional, required for tailwind config)
+
 ## Installation
 
 ```bash
 pnpm i -D eslint @stzhu/eslint-config
 ```
 
+For projects using specific configurations, you may need additional peer dependencies:
+
+- **Tailwind config**: Requires `tailwindcss` and `postcss`
+- **TypeScript projects**: Requires `typescript`
+
+```bash
+# For TypeScript projects
+pnpm i -D typescript
+
+# For Tailwind projects
+pnpm i -D tailwindcss postcss
+```
+
 ## Usage
 
-Create an `eslint.config.js` file in your project root:
+Create an `eslint.config.js` (or `eslint.config.ts` for TypeScript projects) file in your project root:
 
 ```javascript
 // @ts-check
@@ -35,14 +54,16 @@ Choose one of these based on your project type:
 - `@stzhu/eslint-config/node`: Node.js project configuration
 - `@stzhu/eslint-config/expo`: Expo/React Native project configuration
 
+> **Note**: The React config automatically extends the TypeScript config, so you don't need to include both. Similarly, the Expo config includes its own base configuration.
+
 ### Optional Configs
 
 Add these as needed:
 
-- `@stzhu/eslint-config/vitest`: Vitest testing configuration
+- `@stzhu/eslint-config/vitest`: Vitest testing configuration (applies to `**/*.test.{ts,tsx}` files)
 - `@stzhu/eslint-config/storybook`: Storybook configuration
-- `@stzhu/eslint-config/tailwind`: Tailwind CSS configuration
-- `@stzhu/eslint-config/turbo`: Turborepo monorepo
+- `@stzhu/eslint-config/tailwind`: Tailwind CSS configuration (applies to `**/*.tsx` files only)
+- `@stzhu/eslint-config/turbo`: Turborepo monorepo configuration
 - `@stzhu/eslint-config/lingui`: Lingui internationalization configuration
 
 ## Example Configurations

--- a/package.json
+++ b/package.json
@@ -107,14 +107,10 @@
   },
   "peerDependencies": {
     "eslint": "^9",
-    "postcss": "^8",
     "tailwindcss": "^4",
     "typescript": "^5"
   },
   "peerDependenciesMeta": {
-    "postcss": {
-      "optional": true
-    },
     "tailwindcss": {
       "optional": true
     },

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
   },
   "license": "MIT",
   "author": "Steve Zhu <4130171+stevezhu@users.noreply.github.com>",
+  "type": "module",
   "exports": {
     ".": {
       "types": "./dist/index.d.ts",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -68,9 +68,6 @@ importers:
       globals:
         specifier: ^16.2.0
         version: 16.3.0
-      postcss:
-        specifier: ^8
-        version: 8.5.6
       tailwindcss:
         specifier: ^4
         version: 4.1.12

--- a/src/storybook.ts
+++ b/src/storybook.ts
@@ -1,4 +1,4 @@
 import { defineConfig } from 'eslint/config';
 import storybook from 'eslint-plugin-storybook';
 
-export default defineConfig(storybook.configs['flat/recommended']);
+export default defineConfig(storybook.default.configs['flat/recommended']);

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -2,5 +2,5 @@
   "$schema": "https://json.schemastore.org/tsconfig",
   "extends": "@stzhu/tsconfig/tsconfig.base.json",
   "exclude": ["node_modules", "dist"],
-  "compilerOptions": { "module": "ES2022", "moduleResolution": "Bundler" }
+  "compilerOptions": { "module": "Node18", "moduleResolution": "Node16" }
 }


### PR DESCRIPTION
Module exports weren't correct because `"type": "module"` wasn't set in `package.json` which caused .js and .mjs files to be created on build instead of `.js` and `.cjs`.

Additional changes:
- Remove postcss as a peer dependency