### PR TITLE
feat: add remaining TanStack Router functions to react-refresh extraHOCs

### DIFF
--- a/src/react.ts
+++ b/src/react.ts
@@ -47,7 +47,14 @@ export default {
         // References:
         // https://github.com/ArnaudBarre/eslint-plugin-react-refresh/releases/tag/v0.5.0
         // https://bsky.app/profile/arnaud-barre.bsky.social/post/3ma5h5tf2sk2e
-        extraHOCs: ['createRootRouteWithContext'],
+        extraHOCs: [
+          'createFileRoute',
+          'createLazyFileRoute',
+          'createRootRoute',
+          'createRootRouteWithContext',
+          'createRoute',
+          'createLazyRoute',
+        ],
       }),
     ),
   },


### PR DESCRIPTION
## Summary
- Add all TanStack Router route creation functions to the react-refresh plugin's `extraHOCs` list
- Previously only `createRootRouteWithContext` was included; this adds `createFileRoute`, `createLazyFileRoute`, `createRootRoute`, `createRoute`, and `createLazyRoute`
- Reference: https://tanstack.com/router/latest/docs/api/router

## Test plan
- [ ] Verify eslint runs without errors with the updated config
- [ ] Confirm react-refresh no longer warns on components exported via TanStack Router route creation functions

🤖 Generated with [Claude Code](https://claude.com/claude-code)